### PR TITLE
feat: add position to object hash function

### DIFF
--- a/src/filters/arrays.js
+++ b/src/filters/arrays.js
@@ -54,10 +54,10 @@ function matchItems(array1, array2, index1, index2, context) {
     context.hashCache1 = context.hashCache1 || [];
     hash1 = context.hashCache1[index1];
     if (typeof hash1 === 'undefined') {
-      context.hashCache1[index1] = hash1 = objectHash(value1, index1);
+      context.hashCache1[index1] = hash1 = objectHash(value1, index1, 'right');
     }
   } else {
-    hash1 = objectHash(value1);
+    hash1 = objectHash(value1, index1, 'right');
   }
   if (typeof hash1 === 'undefined') {
     return false;
@@ -66,10 +66,10 @@ function matchItems(array1, array2, index1, index2, context) {
     context.hashCache2 = context.hashCache2 || [];
     hash2 = context.hashCache2[index2];
     if (typeof hash2 === 'undefined') {
-      context.hashCache2[index2] = hash2 = objectHash(value2, index2);
+      context.hashCache2[index2] = hash2 = objectHash(value2, index2, 'left');
     }
   } else {
-    hash2 = objectHash(value2);
+    hash2 = objectHash(value2, index2, 'left');
   }
   if (typeof hash2 === 'undefined') {
     return false;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -178,7 +178,7 @@ export class Processor {
 
 export interface Config {
     // used to match objects when diffing arrays, by default only === operator is used
-    objectHash?: (item: any, index: number) => string;
+    objectHash?: (item: any, index: number, position: 'left' | 'right') => string;
 
     arrays?: {
         // default true, detect items moved inside the array (otherwise they will be registered as remove+add)

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -178,7 +178,7 @@ export class Processor {
 
 export interface Config {
     // used to match objects when diffing arrays, by default only === operator is used
-    objectHash?: (item: any, index: number, position: 'left' | 'right') => string;
+    objectHash?: (item: any, index?: number, position?: 'left' | 'right') => string;
 
     arrays?: {
         // default true, detect items moved inside the array (otherwise they will be registered as remove+add)

--- a/test/examples/diffpatch.js
+++ b/test/examples/diffpatch.js
@@ -1378,6 +1378,54 @@ examples.arrays = [
     },
     noPatch: true,
   },
+  {
+    name: 'nested using position',
+    options: {
+      objectHash(obj, _index, position) {
+        if (obj && obj.id && ['left', 'right'].includes(position)) {
+          return obj.id;
+        }
+      },
+    },
+    left: [
+      {
+        id: 4,
+        pos: 'target(left)',
+      },
+      {
+        id: 'five',
+        pos: 'target(left)',
+      },
+    ],
+    right: [
+      {
+        id: 4,
+        pos: 'source(right)',
+      },
+      {
+        id: 'five',
+        pos: 'source(right)',
+      },
+    ],
+    delta: {
+      _t: 'a',
+      0: {
+        pos: ['target(left)', 'source(right)'],
+      },
+      1: {
+        pos: ['target(left)', 'source(right)'],
+      },
+    },
+    reverse: {
+      _t: 'a',
+      0: {
+        pos: ['source(right)', 'target(left)'],
+      },
+      1: {
+        pos: ['source(right)', 'target(left)'],
+      },
+    },
+  },
   0,
 ];
 


### PR DESCRIPTION
Extending the `objectHash` function to be able to also use the position (left or right, i.e. target or source) of the object.