### PR TITLE
chore: adjust types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,21 +5,21 @@ export interface BaseOperation {
 export interface AddOperation<T = any> extends BaseOperation{
   op: 'add';
   value: T;
-};
+}
 
 export interface RemoveOperation extends BaseOperation{
   op: 'remove';
-};
+}
 
 export interface ReplaceOperation<T = any> extends BaseOperation {
   op: 'replace';
   value: T;
-};
+}
 
 export interface MoveOperation extends BaseOperation {
   op: 'move';
   from: string;
-};
+}
 
 export interface CopyOperation extends BaseOperation {
   op: 'copy';


### PR DESCRIPTION
If you try to build the current version in other repositories, you run into this type error:

![image](https://github.com/contentful/jsondiffpatch/assets/43542437/f364013f-d8f6-48d4-a916-ffae0ce0306d)

This fixes it.